### PR TITLE
Modify clear and exit commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,20 +4,21 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.internshipapplication.InternshipApplication;
 
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearCommand extends Command<InternshipApplication> {
 
-    public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String COMMAND_WORD = "/c";
+    public static final String MESSAGE_SUCCESS = "HireMe has been cleared!";
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model<InternshipApplication> model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        model.setAddressBook(new AddressBook<>());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -1,18 +1,19 @@
 package seedu.address.logic.commands;
 
 import seedu.address.model.Model;
+import seedu.address.model.internshipapplication.InternshipApplication;
 
 /**
  * Terminates the program.
  */
-public class ExitCommand extends Command {
+public class ExitCommand extends Command<InternshipApplication> {
 
-    public static final String COMMAND_WORD = "exit";
+    public static final String COMMAND_WORD = "/exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting HireMe as requested ...";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model<InternshipApplication> model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -9,22 +9,25 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.internshipapplication.InternshipApplication;
 
 public class ClearCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
-        Model model = new ModelManager();
-        Model expectedModel = new ModelManager();
+        Model<InternshipApplication> model = new ModelManager<>();
+        Model<InternshipApplication> expectedModel = new ModelManager<>();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel.setAddressBook(new AddressBook());
+        Model<InternshipApplication> model =
+                new ModelManager<InternshipApplication>(getTypicalAddressBook(), new UserPrefs());
+        Model<InternshipApplication> expectedModel =
+                new ModelManager<InternshipApplication>(getTypicalAddressBook(), new UserPrefs());
+        expectedModel.setAddressBook(new AddressBook<>());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -7,14 +7,16 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.internshipapplication.InternshipApplication;
 
 public class ExitCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model<InternshipApplication> model = new ModelManager<>();
+    private Model<InternshipApplication> expectedModel = new ModelManager<>();
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult =
+                new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
## Description
Closes [Clear and Exit HireMe feature #62](https://github.com/AY2425S1-CS2103T-W09-3/tp/issues/62)

Updated the clear and exit commands to be more in line with HireMe's requirements

## Changes made

Previously the clear command worked via typing clear. Now it works by typing /c. The tests have also been updated accordingly. Message variables and values have been changed to be relevant to internship applications

## Testing Steps
Only manual testing so far

ClearCommandTest's and ExitCommandTest's automated tests have been updated accordingly