### PR TITLE
Modify find command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -29,13 +29,41 @@ public class StringUtil {
 
         String preppedWord = word.trim();
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+        checkArgument(preppedWord.split("\\s+").length == 1,
+                "Word parameter should be a single word");
 
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code word}.
+     *   Ignores case, but a full word match is required.
+     *   <br>examples:<pre>
+     *       containsWordIgnoreCase("ABc def", "abc") == true
+     *       containsWordIgnoreCase("ABc def", "DEF") == true
+     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       </pre>
+     * @param sentence cannot be null
+     * @param prefix cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsPrefixIgnoreCase(String sentence, String prefix) {
+        requireNonNull(sentence);
+        requireNonNull(prefix);
+
+        String preppedPrefix = prefix.trim().toLowerCase();
+        checkArgument(!preppedPrefix.isEmpty(), "Prefix parameter cannot be empty");
+        checkArgument(preppedPrefix.split("\\s+").length == 1,
+                "Prefix parameter should be a single word");
+
+        String preppedSentence = sentence.toLowerCase();
+        String[] prefixesInPreppedSentence = preppedSentence.split("\\s+");
+
+        return Arrays.stream(prefixesInPreppedSentence)
+                .anyMatch(preppedSentenceWord -> preppedSentenceWord.contains(preppedPrefix));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,20 +5,22 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.internshipapplication.InternshipApplication;
 import seedu.address.model.internshipapplication.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all internship applications in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-public class FindCommand extends Command {
+public class FindCommand extends Command<InternshipApplication> {
 
-    public static final String COMMAND_WORD = "find";
+    public static final String COMMAND_WORD = "/f";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all internship applications whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " google meta amazon";
 
     private final NameContainsKeywordsPredicate predicate;
 
@@ -27,7 +29,7 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model<InternshipApplication> model) {
         requireNonNull(model);
         model.updateFilteredList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/model/internshipapplication/Company.java
+++ b/src/main/java/seedu/address/model/internshipapplication/Company.java
@@ -51,6 +51,15 @@ public class Company {
     }
 
     /**
+     * Returns the company's name value.
+     *
+     * @return the value of the name object.
+     */
+    public String getNameValue() {
+        return name.getValue();
+    }
+
+    /**
      * Returns the string representation of the company.
      *
      * @return a string that represents the company, including its email and name.

--- a/src/main/java/seedu/address/model/internshipapplication/InternshipApplication.java
+++ b/src/main/java/seedu/address/model/internshipapplication/InternshipApplication.java
@@ -41,6 +41,24 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     }
 
     /**
+     * Returns the company name.
+     *
+     * @return the company name object.
+     */
+    public Name getCompanyName() {
+        return company.getName();
+    }
+
+    /**
+     * Returns the company name value.
+     *
+     * @return the company name string.
+     */
+    public String getCompanyNameValue() {
+        return company.getNameValue();
+    }
+
+    /**
      * Returns the date of application.
      *
      * @return the date of application.

--- a/src/main/java/seedu/address/model/internshipapplication/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/internshipapplication/NameContainsKeywordsPredicate.java
@@ -7,9 +7,9 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Company}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Person> {
+public class NameContainsKeywordsPredicate implements Predicate<InternshipApplication> {
     private final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
@@ -17,9 +17,10 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     }
 
     @Override
-    public boolean test(Person person) {
+    public boolean test(InternshipApplication internshipApplication) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().getValue(), keyword));
+                .anyMatch(keyword -> StringUtil.containsPrefixIgnoreCase(internshipApplication
+                        .getCompanyNameValue(), keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,14 +18,17 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.internshipapplication.InternshipApplication;
 import seedu.address.model.internshipapplication.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model<InternshipApplication> model =
+            new ModelManager<InternshipApplication>(getTypicalAddressBook(), new UserPrefs());
+    private Model<InternshipApplication> expectedModel =
+            new ModelManager<InternshipApplication>(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
@@ -59,9 +62,9 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+        assertEquals(Collections.emptyList(), model.getFilteredList());
     }
 
     @Test
@@ -69,9 +72,9 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredList());
     }
 
     @Test


### PR DESCRIPTION
## Description
Closes [Find internship application feature #66](https://github.com/AY2425S1-CS2103T-W09-3/tp/issues/66)

The previous find command is finding for persons instead of internship applications. Furthermore, it finds them by exact word match which may not be useful. This PR modifies the find command to search for internship applications whose company name contain the search prefix.

## Changes made

Previously, the find command finds by exact word matches (case-insensitive). Now, it has been modified to find by search prefix (case-insensitive).

## Testing Steps
Only manual testing so far

FindCommandTest's automated tests have been updated accordingly. However, further modifications are required if we switch to searching by prefix.
