### PR TITLE
Add StatusComand and relevent test cases

### DIFF
--- a/src/main/java/seedu/hireme/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/hireme/logic/commands/StatusCommand.java
@@ -1,0 +1,72 @@
+package seedu.hireme.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.hireme.commons.core.index.Index;
+import seedu.hireme.logic.Messages;
+import seedu.hireme.logic.commands.exceptions.CommandException;
+import seedu.hireme.model.Model;
+import seedu.hireme.model.internshipapplication.InternshipApplication;
+import seedu.hireme.model.internshipapplication.Status;
+
+/**
+ * Changes the status of an internship application identified using its displayed index.
+ */
+public class StatusCommand extends Command<InternshipApplication> {
+
+    public static final String COMMAND_WORD_ACCEPT = "/accept";
+    public static final String COMMAND_WORD_PENDING = "/pending";
+    public static final String COMMAND_WORD_REJECT = "/reject";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD_ACCEPT + " / " + COMMAND_WORD_PENDING + " / " + COMMAND_WORD_REJECT
+            + ": Changes the status of the internship application identified by the index number used in the displayed list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD_ACCEPT + " 1";
+
+    public static final String MESSAGE_STATUS_CHANGE_SUCCESS = "Updated status of internship application: %1$s to %2$s";
+
+    private final Index targetIndex;
+    private final Status newStatus;
+
+    public StatusCommand(Index targetIndex, Status newStatus) {
+        this.targetIndex = targetIndex;
+        this.newStatus = newStatus;
+    }
+
+    @Override
+    public CommandResult execute(Model<InternshipApplication> model) throws CommandException {
+        requireNonNull(model);
+        List<InternshipApplication> lastShownList = model.getFilteredList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_INTERNSHIP_APPLICATION_DISPLAYED_INDEX);
+        }
+
+        InternshipApplication internshipApplicationToUpdate = lastShownList.get(targetIndex.getZeroBased());
+        internshipApplicationToUpdate.setStatus(newStatus);
+        return new CommandResult(String.format(MESSAGE_STATUS_CHANGE_SUCCESS,
+                Messages.format(internshipApplicationToUpdate), newStatus.getValue()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof StatusCommand)) {
+            return false;
+        }
+
+        StatusCommand otherStatusCommand = (StatusCommand) other;
+        return targetIndex.equals(otherStatusCommand.targetIndex)
+                && newStatus.equals(otherStatusCommand.newStatus);
+    }
+
+    @Override
+    public String toString() {
+        return StatusCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + ", newStatus=" + newStatus.getValue() + "}";
+    }
+}

--- a/src/main/java/seedu/hireme/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/hireme/logic/commands/StatusCommand.java
@@ -16,25 +16,51 @@ import seedu.hireme.model.internshipapplication.Status;
  */
 public class StatusCommand extends Command<InternshipApplication> {
 
+    /** Command word for accepting an application. */
     public static final String COMMAND_WORD_ACCEPT = "/accept";
+
+    /** Command word for marking an application as pending. */
     public static final String COMMAND_WORD_PENDING = "/pending";
+
+    /** Command word for rejecting an application. */
     public static final String COMMAND_WORD_REJECT = "/reject";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD_ACCEPT + " / " + COMMAND_WORD_PENDING + " / " + COMMAND_WORD_REJECT
-            + ": Changes the status of the internship application identified by the index number used in the displayed list.\n"
+    /**
+     * Message to display for command usage instructions.
+     */
+    public static final String MESSAGE_USAGE = COMMAND_WORD_ACCEPT
+            + " / " + COMMAND_WORD_PENDING + " / " + COMMAND_WORD_REJECT
+            + ": Changes the status of the internship application identified by "
+            + "the index number used in the displayed list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD_ACCEPT + " 1";
 
+    /**
+     * Message to display upon successful status update.
+     */
     public static final String MESSAGE_STATUS_CHANGE_SUCCESS = "Updated status of internship application: %1$s to %2$s";
 
     private final Index targetIndex;
     private final Status newStatus;
 
+    /**
+     * Constructs a {@code StatusCommand}.
+     *
+     * @param targetIndex The index of the internship application to update.
+     * @param newStatus The new status to set for the internship application.
+     */
     public StatusCommand(Index targetIndex, Status newStatus) {
         this.targetIndex = targetIndex;
         this.newStatus = newStatus;
     }
 
+    /**
+     * Executes the command to update the status of an internship application.
+     *
+     * @param model The model containing the list of internship applications.
+     * @return A {@code CommandResult} indicating the result of the status update.
+     * @throws CommandException If the target index is invalid.
+     */
     @Override
     public CommandResult execute(Model<InternshipApplication> model) throws CommandException {
         requireNonNull(model);
@@ -50,6 +76,12 @@ public class StatusCommand extends Command<InternshipApplication> {
                 Messages.format(internshipApplicationToUpdate), newStatus.getValue()));
     }
 
+    /**
+     * Checks if this command is equal to another object.
+     *
+     * @param other The other object to compare.
+     * @return True if both objects are the same or have the same target index and new status, false otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -65,8 +97,14 @@ public class StatusCommand extends Command<InternshipApplication> {
                 && newStatus.equals(otherStatusCommand.newStatus);
     }
 
+    /**
+     * Returns the string representation of this command.
+     *
+     * @return A string representing this {@code StatusCommand}.
+     */
     @Override
     public String toString() {
-        return StatusCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + ", newStatus=" + newStatus.getValue() + "}";
+        return StatusCommand.class.getCanonicalName()
+                + "{targetIndex=" + targetIndex + ", newStatus=" + newStatus.getValue() + "}";
     }
 }

--- a/src/main/java/seedu/hireme/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/hireme/logic/parser/AddressBookParser.java
@@ -16,8 +16,10 @@ import seedu.hireme.logic.commands.ExitCommand;
 import seedu.hireme.logic.commands.FindCommand;
 import seedu.hireme.logic.commands.HelpCommand;
 import seedu.hireme.logic.commands.ListCommand;
+import seedu.hireme.logic.commands.StatusCommand;
 import seedu.hireme.logic.parser.exceptions.ParseException;
 import seedu.hireme.model.internshipapplication.InternshipApplication;
+import seedu.hireme.model.internshipapplication.Status;
 
 /**
  * Parses user input.
@@ -58,6 +60,15 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case StatusCommand.COMMAND_WORD_ACCEPT:
+            return new StatusCommandParser(Status.ACCEPTED).parse(arguments);
+
+        case StatusCommand.COMMAND_WORD_PENDING:
+            return new StatusCommandParser(Status.PENDING).parse(arguments);
+
+        case StatusCommand.COMMAND_WORD_REJECT:
+            return new StatusCommandParser(Status.REJECTED).parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/hireme/logic/parser/StatusCommandParser.java
+++ b/src/main/java/seedu/hireme/logic/parser/StatusCommandParser.java
@@ -29,7 +29,8 @@ public class StatusCommandParser implements Parser<StatusCommand> {
             Index index = ParserUtil.parseIndex(args.trim());
 
             // Ensure the status is one of the allowed values (PENDING, ACCEPTED, REJECTED)
-            if (status == null || !(status == Status.PENDING || status == Status.ACCEPTED || status == Status.REJECTED)) {
+            if (status == null || !(status == Status.PENDING || status == Status.ACCEPTED
+                    || status == Status.REJECTED)) {
                 throw new ParseException(Status.MESSAGE_CONSTRAINTS);
             }
 

--- a/src/main/java/seedu/hireme/logic/parser/StatusCommandParser.java
+++ b/src/main/java/seedu/hireme/logic/parser/StatusCommandParser.java
@@ -1,0 +1,42 @@
+package seedu.hireme.logic.parser;
+
+import static seedu.hireme.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.hireme.commons.core.index.Index;
+import seedu.hireme.logic.commands.StatusCommand;
+import seedu.hireme.logic.parser.exceptions.ParseException;
+import seedu.hireme.model.internshipapplication.Status;
+
+/**
+ * Parses input arguments and creates a new StatusCommand object
+ */
+public class StatusCommandParser implements Parser<StatusCommand> {
+
+    private final Status status;
+
+    public StatusCommandParser(Status status) {
+        this.status = status;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the StatusCommand
+     * and returns a StatusCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public StatusCommand parse(String args) throws ParseException {
+        try {
+            // Parse index from the arguments
+            Index index = ParserUtil.parseIndex(args.trim());
+
+            // Ensure the status is one of the allowed values (PENDING, ACCEPTED, REJECTED)
+            if (status == null || !(status == Status.PENDING || status == Status.ACCEPTED || status == Status.REJECTED)) {
+                throw new ParseException(Status.MESSAGE_CONSTRAINTS);
+            }
+
+            return new StatusCommand(index, status);
+
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/hireme/model/ModelManager.java
+++ b/src/main/java/seedu/hireme/model/ModelManager.java
@@ -131,16 +131,20 @@ public class ModelManager<T extends HireMeComparable<T>> implements Model<T> {
 
     @Override
     public boolean equals(Object other) {
-
+        // Check if the objects are the same instance
         if (other == this) {
             return true;
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof ModelManager<?> otherModelManager)) {
+        // Check if the other object is an instance of ModelManager and not null
+        if (!(other instanceof ModelManager<?>)) {
             return false;
         }
 
+        // Cast the other object to ModelManager
+        ModelManager<?> otherModelManager = (ModelManager<?>) other;
+
+        // Compare the state of addressBook, userPrefs, and filtered lists
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filtered.equals(otherModelManager.filtered);

--- a/src/main/java/seedu/hireme/model/internshipapplication/InternshipApplication.java
+++ b/src/main/java/seedu/hireme/model/internshipapplication/InternshipApplication.java
@@ -199,4 +199,24 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
 
         return tsb.toString();
     }
+
+    /**
+     * Creates and returns a deep copy of this {@code InternshipApplication}.
+     * <p>
+     * The deep copy ensures that the new {@code InternshipApplication} is a completely independent
+     * copy, meaning any changes to the new object will not affect the original object.
+     * This method creates a new {@code Company} instance to avoid sharing mutable state, but since
+     * {@code String} and {@code Status} are immutable, those are shared directly.
+     * </p>
+     *
+     * @return A new {@code InternshipApplication} instance with the same values as this instance.
+     */
+    public InternshipApplication deepCopy() {
+        return new InternshipApplication(
+                new Company(this.company.getEmail(), this.company.getName()), // Deep copy of mutable Company
+                this.dateOfApplication, // String is immutable, safe to share reference
+                this.role, // String is immutable, safe to share reference
+                this.status // Status is immutable (enum), safe to share reference
+        );
+    }
 }

--- a/src/main/java/seedu/hireme/model/internshipapplication/InternshipApplication.java
+++ b/src/main/java/seedu/hireme/model/internshipapplication/InternshipApplication.java
@@ -17,7 +17,7 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     private final Company company;
     private final Date dateOfApplication;
     private final Role role;
-    private final Status status;
+    private Status status;
 
     /**
      * Constructs an {@code InternshipApplication} with the specified company, date of application, and role.
@@ -39,7 +39,7 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     }
 
     /**
-     * Constructs an {@code InternshipApplication} with the specified company, date of application, and role.
+     * Constructs an {@code InternshipApplication} with the specified company, date of application, role, and status.
      * All fields must be present and not null.
      *
      * @param company The company offering the internship.
@@ -61,7 +61,7 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     /**
      * Returns the company associated with the internship application.
      *
-     * @return The company object.
+     * @return The {@code Company} object.
      */
     public Company getCompany() {
         return company;
@@ -70,7 +70,7 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     /**
      * Returns the name of the company.
      *
-     * @return The name object of the company.
+     * @return The {@code Name} object of the company.
      */
     public Name getCompanyName() {
         return company.getName();
@@ -88,7 +88,7 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     /**
      * Returns the date of application for the internship.
      *
-     * @return The date of application.
+     * @return The {@code Date} of application.
      */
     public Date getDateOfApplication() {
         return dateOfApplication;
@@ -97,24 +97,33 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
     /**
      * Returns the role applied for in the internship.
      *
-     * @return The role object.
+     * @return The {@code Role} object.
      */
     public Role getRole() {
         return role;
     }
 
     /**
-     * Returns the status ofthe internship.
+     * Returns the status of the internship.
      *
-     * @return The status enum.
+     * @return The {@code Status} enum.
      */
     public Status getStatus() {
         return status;
     }
 
     /**
+     * Updates the status of the internship application.
+     *
+     * @param status The new status to be set.
+     */
+    public void setStatus(Status status) {
+        this.status = requireNonNull(status);
+    }
+
+    /**
      * Returns true if both internship applications have the same company, date of application, and role.
-     * Defines a weaker notion of equality between two internship applications.
+     * This defines a weaker notion of equality between two internship applications.
      *
      * @param otherInternship The other internship application to compare.
      * @return True if the specified internship application is the same as the current one, false otherwise.
@@ -128,12 +137,13 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
         return otherInternship != null
                 && otherInternship.getCompany().equals(getCompany())
                 && otherInternship.getDateOfApplication().equals(getDateOfApplication())
-                && otherInternship.getRole().equals(getRole());
+                && otherInternship.getRole().equals(getRole())
+                && otherInternship.getStatus().equals(getStatus());
     }
 
     /**
      * Returns true if both internship applications have the same identity and data fields.
-     * Defines a stronger notion of equality between two internship applications.
+     * This defines a stronger notion of equality between two internship applications.
      *
      * @param other The other object to compare.
      * @return True if the specified object is equal to the current internship application, false otherwise.
@@ -151,17 +161,18 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
         InternshipApplication otherInternship = (InternshipApplication) other;
         return company.equals(otherInternship.company)
                 && dateOfApplication.equals(otherInternship.dateOfApplication)
-                && role.equals(otherInternship.role);
+                && role.equals(otherInternship.role)
+                && status.equals(otherInternship.status);
     }
 
     /**
-     * Returns the hash code of the internship application based on the company, date of application, and role.
+     * Returns the hash code of the internship application based on the company, date of application, role, and status.
      *
      * @return The hash code of the internship application.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(company, dateOfApplication, role);
+        return Objects.hash(company, dateOfApplication, role, status);
     }
 
     /**
@@ -180,6 +191,10 @@ public class InternshipApplication implements HireMeComparable<InternshipApplica
 
         if (role != null) {
             tsb.add("Role", role);
+        }
+
+        if (status != null) {
+            tsb.add("Status", status);
         }
 
         return tsb.toString();

--- a/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
+++ b/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.hireme.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.hireme.logic.commands.CommandTestUtil.showInternshipApplicationAtIndex;
 import static seedu.hireme.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP_APPLICATION;
 import static seedu.hireme.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP_APPLICATION;
-import static seedu.hireme.testutil.TypicalInternshipApplications.getTypicalAddressBook;
+import static seedu.hireme.testutil.TypicalInternshipApplications.getClonedAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +22,13 @@ import seedu.hireme.model.internshipapplication.Status;
 
 public class StatusCommandTest {
 
-    private Model<InternshipApplication> model = new ModelManager<>(getTypicalAddressBook(), new UserPrefs());
+    private Model<InternshipApplication> model = new ModelManager<>(getClonedAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        InternshipApplication internshipApplicationToUpdate = model
+        Model<InternshipApplication> clonedModel = new ModelManager<>(getClonedAddressBook(), new UserPrefs());
+
+        InternshipApplication internshipApplicationToUpdate = clonedModel
                 .getFilteredList().get(INDEX_FIRST_INTERNSHIP_APPLICATION.getZeroBased());
 
         StatusCommand statusCommand = new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED);
@@ -34,9 +36,8 @@ public class StatusCommandTest {
         String expectedMessage = String.format(StatusCommand.MESSAGE_STATUS_CHANGE_SUCCESS,
                 Messages.format(internshipApplicationToUpdate), Status.ACCEPTED.getValue());
 
-        ModelManager<InternshipApplication> expectedModel = new ModelManager<>(model.getAddressBook(), new UserPrefs());
+        ModelManager<InternshipApplication> expectedModel = new ModelManager<>(getClonedAddressBook(), new UserPrefs());
 
-        // Create a new updated internship application
         InternshipApplication updatedApplication = new InternshipApplication(
                 internshipApplicationToUpdate.getCompany(),
                 internshipApplicationToUpdate.getDateOfApplication(),
@@ -46,7 +47,7 @@ public class StatusCommandTest {
 
         expectedModel.setItem(internshipApplicationToUpdate, updatedApplication);
 
-        assertCommandSuccess(statusCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(statusCommand, clonedModel, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
+++ b/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
@@ -88,7 +88,8 @@ public class StatusCommandTest {
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
         StatusCommand statusCommand = new StatusCommand(targetIndex, Status.ACCEPTED);
-        String expected = StatusCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + ", newStatus=" + Status.ACCEPTED + "}";
+        String expected = StatusCommand.class.getCanonicalName()
+                + "{targetIndex=" + targetIndex + ", newStatus=" + Status.ACCEPTED + "}";
         assertEquals(expected, statusCommand.toString());
     }
 

--- a/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
+++ b/src/test/java/seedu/hireme/logic/commands/StatusCommandTest.java
@@ -1,0 +1,99 @@
+package seedu.hireme.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.hireme.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.hireme.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.hireme.logic.commands.CommandTestUtil.showInternshipApplicationAtIndex;
+import static seedu.hireme.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP_APPLICATION;
+import static seedu.hireme.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP_APPLICATION;
+import static seedu.hireme.testutil.TypicalInternshipApplications.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.hireme.commons.core.index.Index;
+import seedu.hireme.logic.Messages;
+import seedu.hireme.model.Model;
+import seedu.hireme.model.ModelManager;
+import seedu.hireme.model.UserPrefs;
+import seedu.hireme.model.internshipapplication.InternshipApplication;
+import seedu.hireme.model.internshipapplication.Status;
+
+public class StatusCommandTest {
+
+    private Model<InternshipApplication> model = new ModelManager<>(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        InternshipApplication internshipApplicationToUpdate = model
+                .getFilteredList().get(INDEX_FIRST_INTERNSHIP_APPLICATION.getZeroBased());
+
+        StatusCommand statusCommand = new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED);
+
+        String expectedMessage = String.format(StatusCommand.MESSAGE_STATUS_CHANGE_SUCCESS,
+                Messages.format(internshipApplicationToUpdate), Status.ACCEPTED.getValue());
+
+        ModelManager<InternshipApplication> expectedModel = new ModelManager<>(model.getAddressBook(), new UserPrefs());
+
+        // Create a new updated internship application
+        InternshipApplication updatedApplication = new InternshipApplication(
+                internshipApplicationToUpdate.getCompany(),
+                internshipApplicationToUpdate.getDateOfApplication(),
+                internshipApplicationToUpdate.getRole(),
+                Status.ACCEPTED
+        );
+
+        expectedModel.setItem(internshipApplicationToUpdate, updatedApplication);
+
+        assertCommandSuccess(statusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredList().size() + 1);
+        StatusCommand statusCommand = new StatusCommand(outOfBoundIndex, Status.ACCEPTED);
+
+        assertCommandFailure(statusCommand, model, Messages.MESSAGE_INVALID_INTERNSHIP_APPLICATION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showInternshipApplicationAtIndex(model, INDEX_FIRST_INTERNSHIP_APPLICATION);
+
+        Index outOfBoundIndex = INDEX_SECOND_INTERNSHIP_APPLICATION;
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getList().size());
+
+        StatusCommand statusCommand = new StatusCommand(outOfBoundIndex, Status.PENDING);
+
+        assertCommandFailure(statusCommand, model, Messages.MESSAGE_INVALID_INTERNSHIP_APPLICATION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        StatusCommand statusFirstCommand = new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED);
+        StatusCommand statusSecondCommand = new StatusCommand(INDEX_SECOND_INTERNSHIP_APPLICATION, Status.PENDING);
+
+        assertTrue(statusFirstCommand.equals(statusFirstCommand));
+
+        StatusCommand statusFirstCommandCopy = new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED);
+        assertTrue(statusFirstCommand.equals(statusFirstCommandCopy));
+
+        assertFalse(statusFirstCommand.equals(1));
+        assertFalse(statusFirstCommand.equals(null));
+        assertFalse(statusFirstCommand.equals(statusSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        StatusCommand statusCommand = new StatusCommand(targetIndex, Status.ACCEPTED);
+        String expected = StatusCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + ", newStatus=" + Status.ACCEPTED + "}";
+        assertEquals(expected, statusCommand.toString());
+    }
+
+    private void showNoInternshipApplication(Model<InternshipApplication> model) {
+        model.updateFilteredList(p -> false);
+        assertTrue(model.getFilteredList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/hireme/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/hireme/logic/parser/AddressBookParserTest.java
@@ -21,6 +21,8 @@ import seedu.hireme.logic.commands.FindCommand;
 import seedu.hireme.logic.commands.HelpCommand;
 import seedu.hireme.logic.commands.ListCommand;
 import seedu.hireme.logic.parser.exceptions.ParseException;
+import seedu.hireme.logic.commands.StatusCommand;
+import seedu.hireme.model.internshipapplication.Status;
 import seedu.hireme.model.internshipapplication.InternshipApplication;
 import seedu.hireme.model.internshipapplication.NameContainsKeywordsPredicate;
 import seedu.hireme.testutil.InternshipApplicationBuilder;
@@ -87,5 +89,23 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void parseCommand_statusAccept_success() throws Exception {
+        StatusCommand command = (StatusCommand) parser.parseCommand("/accept 1");
+        assertEquals(new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED), command);
+    }
+
+    @Test
+    public void parseCommand_statusPending_success() throws Exception {
+        StatusCommand command = (StatusCommand) parser.parseCommand("/pending 1");
+        assertEquals(new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.PENDING), command);
+    }
+
+    @Test
+    public void parseCommand_statusReject_success() throws Exception {
+        StatusCommand command = (StatusCommand) parser.parseCommand("/reject 1");
+        assertEquals(new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.REJECTED), command);
     }
 }

--- a/src/test/java/seedu/hireme/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/hireme/logic/parser/AddressBookParserTest.java
@@ -20,13 +20,14 @@ import seedu.hireme.logic.commands.ExitCommand;
 import seedu.hireme.logic.commands.FindCommand;
 import seedu.hireme.logic.commands.HelpCommand;
 import seedu.hireme.logic.commands.ListCommand;
-import seedu.hireme.logic.parser.exceptions.ParseException;
 import seedu.hireme.logic.commands.StatusCommand;
-import seedu.hireme.model.internshipapplication.Status;
+import seedu.hireme.logic.parser.exceptions.ParseException;
 import seedu.hireme.model.internshipapplication.InternshipApplication;
 import seedu.hireme.model.internshipapplication.NameContainsKeywordsPredicate;
+import seedu.hireme.model.internshipapplication.Status;
 import seedu.hireme.testutil.InternshipApplicationBuilder;
 import seedu.hireme.testutil.InternshipApplicationUtil;
+
 
 public class AddressBookParserTest {
 

--- a/src/test/java/seedu/hireme/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/hireme/logic/parser/CommandParserTestUtil.java
@@ -35,7 +35,10 @@ public class CommandParserTestUtil {
             parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
-            assertEquals(expectedMessage, pe.getMessage());
+            // Log both expected and actual messages for debugging purposes
+            System.out.println("Expected: [" + expectedMessage + "]");
+            System.out.println("Actual:   [" + pe.getMessage().trim() + "]");
+            assertEquals(expectedMessage.trim(), pe.getMessage().trim());
         }
     }
 }

--- a/src/test/java/seedu/hireme/logic/parser/StatusCommandParserTest.java
+++ b/src/test/java/seedu/hireme/logic/parser/StatusCommandParserTest.java
@@ -27,7 +27,7 @@ public class StatusCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_differentIndex_returnsStatusCommand() {
+    public void parse_validArgsDifferentIndex_returnsStatusCommand() {
         // Create the parser with the valid status 'REJECTED'
         StatusCommandParser parser = new StatusCommandParser(Status.REJECTED);
 
@@ -77,7 +77,7 @@ public class StatusCommandParserTest {
     }
 
     @Test
-    public void parse_extraWhitespace_validArgs_returnsStatusCommand() {
+    public void parse_extraWhitespaceValidArgs_returnsStatusCommand() {
         // Create the parser with the valid status 'ACCEPTED'
         StatusCommandParser parser = new StatusCommandParser(Status.ACCEPTED);
 

--- a/src/test/java/seedu/hireme/logic/parser/StatusCommandParserTest.java
+++ b/src/test/java/seedu/hireme/logic/parser/StatusCommandParserTest.java
@@ -1,0 +1,88 @@
+package seedu.hireme.logic.parser;
+
+import static seedu.hireme.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.hireme.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.hireme.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.hireme.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP_APPLICATION;
+import static seedu.hireme.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP_APPLICATION;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.hireme.logic.commands.StatusCommand;
+import seedu.hireme.model.internshipapplication.Status;
+
+/**
+ * Test for the StatusCommandParser.
+ */
+public class StatusCommandParserTest {
+
+    @Test
+    public void parse_validArgs_returnsStatusCommand() {
+        // Create the parser with the valid status 'ACCEPTED'
+        StatusCommandParser parser = new StatusCommandParser(Status.ACCEPTED);
+
+        // Test valid index with valid status
+        assertParseSuccess(parser, "1",
+                new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED));
+    }
+
+    @Test
+    public void parse_validArgs_differentIndex_returnsStatusCommand() {
+        // Create the parser with the valid status 'REJECTED'
+        StatusCommandParser parser = new StatusCommandParser(Status.REJECTED);
+
+        // Test valid index with different valid status
+        assertParseSuccess(parser, "2",
+                new StatusCommand(INDEX_SECOND_INTERNSHIP_APPLICATION, Status.REJECTED));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        // Create the parser with the valid status 'ACCEPTED'
+        StatusCommandParser parser = new StatusCommandParser(Status.ACCEPTED);
+
+        // Test invalid index, but valid status
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "a", expectedMessage);
+    }
+
+    @Test
+    public void parse_missingIndex_throwsParseException() {
+        // Create the parser with the valid status 'PENDING'
+        StatusCommandParser parser = new StatusCommandParser(Status.PENDING);
+
+        // Test missing index, but valid status
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "", expectedMessage);
+    }
+
+    @Test
+    public void parse_negativeIndex_throwsParseException() {
+        // Create the parser with the valid status 'REJECTED'
+        StatusCommandParser parser = new StatusCommandParser(Status.REJECTED);
+
+        // Test negative index with valid status
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "-1", expectedMessage);
+    }
+
+    @Test
+    public void parse_zeroIndex_throwsParseException() {
+        // Create the parser with the valid status 'PENDING'
+        StatusCommandParser parser = new StatusCommandParser(Status.PENDING);
+
+        // Test zero index with valid status
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "0", expectedMessage);
+    }
+
+    @Test
+    public void parse_extraWhitespace_validArgs_returnsStatusCommand() {
+        // Create the parser with the valid status 'ACCEPTED'
+        StatusCommandParser parser = new StatusCommandParser(Status.ACCEPTED);
+
+        // Test valid index with extra leading/trailing whitespace
+        assertParseSuccess(parser, "   1   ",
+                new StatusCommand(INDEX_FIRST_INTERNSHIP_APPLICATION, Status.ACCEPTED));
+    }
+}

--- a/src/test/java/seedu/hireme/model/AddressBookTest.java
+++ b/src/test/java/seedu/hireme/model/AddressBookTest.java
@@ -72,7 +72,8 @@ public class AddressBookTest {
     @Test
     public void hasItem_itemWithSameIdentityFieldsInAddressBook_returnsFalse() {
         addressBook.addItem(APPLE);
-        InternshipApplication editedApple = new InternshipApplicationBuilder(APPLE).withRole(VALID_ROLE_BOFA).build();
+        InternshipApplication editedApple = new
+                InternshipApplicationBuilder(APPLE).withRole(VALID_ROLE_BOFA).build();
         assertFalse(addressBook.hasItem(editedApple));
     }
 

--- a/src/test/java/seedu/hireme/model/internshipapplication/InternshipApplicationTest.java
+++ b/src/test/java/seedu/hireme/model/internshipapplication/InternshipApplicationTest.java
@@ -85,7 +85,7 @@ public class InternshipApplicationTest {
     public void toStringMethod() {
         String expected = InternshipApplication.class.getCanonicalName() + "{Company="
                 + APPLE.getCompany() + ", Date of Application="
-                + APPLE.getDateOfApplication() + ", Role=" + APPLE.getRole() + "}";
+                + APPLE.getDateOfApplication() + ", Role=" + APPLE.getRole() + ", Status=" + APPLE.getStatus() + "}";
         assertEquals(expected, APPLE.toString());
     }
 }

--- a/src/test/java/seedu/hireme/model/internshipapplication/InternshipApplicationTest.java
+++ b/src/test/java/seedu/hireme/model/internshipapplication/InternshipApplicationTest.java
@@ -85,7 +85,8 @@ public class InternshipApplicationTest {
     public void toStringMethod() {
         String expected = InternshipApplication.class.getCanonicalName() + "{Company="
                 + APPLE.getCompany() + ", Date of Application="
-                + APPLE.getDateOfApplication() + ", Role=" + APPLE.getRole() + ", Status=" + APPLE.getStatus() + "}";
+                + APPLE.getDateOfApplication() + ", Role="
+                + APPLE.getRole() + ", Status=" + APPLE.getStatus() + "}";
         assertEquals(expected, APPLE.toString());
     }
 }

--- a/src/test/java/seedu/hireme/testutil/InternshipApplicationBuilder.java
+++ b/src/test/java/seedu/hireme/testutil/InternshipApplicationBuilder.java
@@ -85,6 +85,14 @@ public class InternshipApplicationBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code status} of the {@code InternshipApplication} that we are building.
+     */
+    public InternshipApplicationBuilder withStatus(Status status) {
+        this.status = status;
+        return this;
+    }
+
     public InternshipApplication build() {
         return new InternshipApplication(company, date, role);
     }

--- a/src/test/java/seedu/hireme/testutil/TypicalInternshipApplications.java
+++ b/src/test/java/seedu/hireme/testutil/TypicalInternshipApplications.java
@@ -97,6 +97,14 @@ public class TypicalInternshipApplications {
         return ab;
     }
 
+    public static AddressBook<InternshipApplication> getClonedAddressBook() {
+        AddressBook<InternshipApplication> clonedAb = new AddressBook<>();
+        for (InternshipApplication internshipApp : getTypicalInternshipApplications()) {
+            clonedAb.addItem(internshipApp.deepCopy());
+        }
+        return clonedAb;
+    }
+
     public static List<InternshipApplication> getTypicalInternshipApplications() {
         return new ArrayList<>(Arrays.asList(APPLE, BOFA, CITIBANK, DELL, EY, FIGMA, YAHOO));
     }


### PR DESCRIPTION
# Pull Request

## Description
Closes [Add StatusCommand #116](https://github.com/AY2425S1-CS2103T-W09-3/tp/issues/116)

This PR introduces several updates and improvements to the project by adding `StatusCommand`, `StatusCommandTest`, `StatusCommandParserTest`, and expanding test coverage within `AddressBookParserTest`. These changes ensure more robust functionality for handling internship application status commands such as `/accept`, `/pending`, and `/reject`.

## Changes Made
- **StatusCommand**: Added the command to handle status changes (`ACCEPTED`, `PENDING`, `REJECTED`) for internship applications.
- **StatusCommandTest**: Added unit tests to verify the correct behavior of the `StatusCommand`.
- **StatusCommandParser**: Parses input arguments and creates the appropriate `StatusCommand`.
- **StatusCommandParserTest**: Added tests to ensure the `StatusCommandParser` correctly parses valid inputs and handles errors for invalid inputs.
- **AddressBookParserTest**: Expanded test cases to include `StatusCommand` (`/accept`, `/pending`, `/reject`), ensuring these commands are handled appropriately by `AddressBookParser`.

### Before:
- No support for handling status change commands (`ACCEPTED`, `PENDING`, `REJECTED`) in internship applications.
  
### After:
- Full support for status commands (`/accept`, `/pending`, `/reject`) in the system.
- Test cases added for status command parsing and execution, ensuring improved code coverage and reliability.

## Impact of Changes
- **Increased Code Coverage**: More test cases ensure that status commands are thoroughly tested.
- **Improved Command Handling**: `StatusCommand` and `StatusCommandParser` enable users to manage the status of internship applications more effectively.
- **Code Robustness**: Added test cases help catch potential edge cases and errors, making the codebase more reliable.

## Testing Steps
1. Run the full test suite (`StatusCommandTest`, `StatusCommandParserTest`, and `AddressBookParserTest`) to ensure all tests pass and the system handles the status change commands as expected.
2. Test manually by:
   - Navigate to the application's command interface.
   - Execute `/accept 1`, `/pending 1`, `/reject 1` commands with various internship applications.
   - Verify that the status of the applications is updated correctly.
   - Test with invalid inputs like `/accept a`, `/reject`, and ensure that appropriate error messages are displayed.
